### PR TITLE
Add argocd CLI to create applications

### DIFF
--- a/config/3.2/cp4waiops/templates/00-argocd-admin.yaml
+++ b/config/3.2/cp4waiops/templates/00-argocd-admin.yaml
@@ -1,34 +1,30 @@
 ---
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
 metadata:
+  name: argocd-admin
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
-  creationTimestamp: null
-  name: argocd-admin
-  namespace: {{.Values.spec.cp4waiops_namespace}}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
 subjects:
   - kind: ServiceAccount
     name: argocd-cluster-argocd-application-controller
     namespace: openshift-gitops
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-  creationTimestamp: null
-  name: openshift-gitops-admin
-  namespace: {{.Values.spec.cp4waiops_namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admin
+  name: cluster-admin
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-argocd-admin
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 subjects:
   - kind: ServiceAccount
     name: openshift-gitops-argocd-application-controller
     namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin


### PR DESCRIPTION
- Add argocd CLI to create applications. [#15]( https://github.com/cloud-pak-gitops/cp4waiops-gitops/issues/15)

- Fix argocd permission  issue
   When created the storage class (ceph), we give the cluster admin permission to argocd.  https://github.com/cloud-pak-gitops/cp4waiops-gitops/blob/main/ceph/00-argocd-admin.yaml . But if we don't create storage through this [method,](https://github.com/cloud-pak-gitops/cp4waiops-gitops/blob/main/docs/how-to-deploy-cp4waiops-32.md#storage-consideration) argocd permissions will be insufficient when creating cp4waiops. So modify the permission of argocd here to cluster admin 

Fixed #15 