### PR TITLE
Delete aiops-ir-analytic failed pod after patching service account

### DIFF
--- a/config/3.2/cp4waiops/templates/patch-serviceaccount.yaml
+++ b/config/3.2/cp4waiops/templates/patch-serviceaccount.yaml
@@ -72,6 +72,11 @@ spec:
                 oc delete pod ${aiops_topology_name} -n {{.Values.spec.cp4waiops_namespace}}
               fi
 
+              aiops_ir_name=$(kubectl get pod -n {{.Values.spec.cp4waiops_namespace}} | grep aiops-ir-analytics | awk '{print $1}')
+              if [[ "${aiops_ir_name}" != "" ]]; then
+                oc delete pod ${aiops_ir_name} -n {{.Values.spec.cp4waiops_namespace}}
+              fi
+
       restartPolicy: Never
       serviceAccountName: openshift-gitops-argocd-application-controller
   backoffLimit: 4


### PR DESCRIPTION
Delete `aiops-ir-analytic-*` failed pods  after patching service account.

cc @morningspace 